### PR TITLE
loaded Android Gradle Plugin Conditionally

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,11 +1,16 @@
 buildscript {
-  repositories {
+  // The Android Gradle plugin is only required when opening the Android folder stand-alone.
+  // This avoids unnecessary downloads and potential conflicts when the library is included as a
+  // module dependency in an application project.
+  if (project == rootProject) {
+    repositories {
       google()
       mavenCentral()
-  }
+    }
 
-  dependencies {
-    classpath 'com.android.tools.build:gradle:3.5.3'
+    dependencies {
+      classpath 'com.android.tools.build:gradle:3.5.3'
+    }
   }
 }
 


### PR DESCRIPTION
This wraps the Android Gradle plugin dependency in the buildscripts section of android/build.gradle in a conditional:

```
if (project == rootProject) {
    // ... (dependency here)
}
```

The Android Gradle plugin is only required when opening the project stand-alone, not when it is included as a dependency. By doing this, the project opens correctly in Android Studio, and it can also be consumed as a native module dependency from an application project without affecting the app project (avoiding unnecessary downloads/conflicts/etc).

for more info, you can refer to [this thread](https://github.com/facebook/react-native/pull/25569) and especially [this comment.](https://github.com/facebook/react-native/pull/25569#issuecomment-532504277)